### PR TITLE
Add option to regenerate missing world rather than discarding config.

### DIFF
--- a/src/main/java/me/lokka30/phantomworlds/managers/WorldManager.java
+++ b/src/main/java/me/lokka30/phantomworlds/managers/WorldManager.java
@@ -103,12 +103,22 @@ public class WorldManager {
 
     final File worldFolder = new File(Bukkit.getWorldContainer(), worldName);
     final File levelDat = new File(worldFolder, "level.dat");
+
+    // The world was deleted/moved by the user.
     if(!worldFolder.exists() || !levelDat.exists()) {
 
-      // The world was deleted/moved by the user so it must be re-imported. PW should no longer attempt to load that world.
-      PhantomWorlds.logger().info("Discarding world '" + worldName + "' from PhantomWorlds' "
-                                  + "data file as it no longer exists on the server.");
-      return WorldLoadResponse.INVALID;
+      if(PhantomWorlds.instance().settings.getConfig().getBoolean("regenerate-missing-worlds", false)) {
+        // PW should regenerate new world data as per the user's configuration.
+        PhantomWorlds.logger().info("Can not find world '" + worldName + "' from PhantomWorlds' "
+                + "data file! Regenerating world... ");
+        getPhantomWorldFromData(worldName).create();
+      }
+      else {
+        // PW should no longer attempt to load that world.
+        PhantomWorlds.logger().info("Discarding world '" + worldName + "' from PhantomWorlds' "
+                + "data file as it no longer exists on the server.");
+        return WorldLoadResponse.INVALID;
+      }
     }
 
     if(PhantomWorlds.instance().data.getConfig().getBoolean("worlds-to-load." + worldName + ".skip-autoload", false)) {

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -32,6 +32,9 @@ delete-archive: true
 #Should worlds be automatically backed up to the backup folder?
 backup-scheduler: false
 
+#Should PW regenerate worlds in the config that are missing from disk?
+regenerate-missing-worlds: false
+
 #The time, in seconds, to back up every PhantomWorlds-managed world.
 backup-delay: 600
 


### PR DESCRIPTION
Adds `regenerate-missing-worlds` to `settings.yml`, with the default being `false` (keeping behavior in-line with previous versions).

This should allow for niche use cases, i.e a test server environment with config mirrored from production. Generating a new world in-place with the same configuration allows for server developers to make stand-in test worlds for their production counterparts.

Without this option, tracking and potentially losing a world's configuration due to not manually regenerating a new test world becomes a nightmare.